### PR TITLE
Support element references in type definitions

### DIFF
--- a/test/fixtures/stock_quote.wsdl
+++ b/test/fixtures/stock_quote.wsdl
@@ -27,6 +27,7 @@
            </all>
          </complexType>
       </element>
+      <element name="specialTickerSymbol" type="xsd2:TickerSymbol"/>
       <element name="authentication">
         <sequence>
           <element name="username" type="xs:string"/>
@@ -44,7 +45,7 @@
           <extension base="xsd1:BaseRequest">
             <sequence>
               <element name="tickerSymbol" type="xs:string" maxOccurs="5"/>
-              <element name="specialTickerSymbol" type="xsd2:TickerSymbol" maxOccurs="unbounded"/>
+              <element ref="tns:specialTickerSymbol" maxOccurs="unbounded"/>
             </sequence>
             <attribute name="id" type="xs:string"/>
           </extension>

--- a/test/unit/test_wsdl_parser.rb
+++ b/test/unit/test_wsdl_parser.rb
@@ -141,6 +141,11 @@ module LolSoap
               :attributes => []
             }
           },
+          [namespace, "specialTickerSymbol"] => {
+            :name      => "specialTickerSymbol",
+            :namespace => namespace,
+            :type      => [namespace2, 'TickerSymbol']
+          },
           [namespace, "historicalPriceRequest"] => {
             :name      => "historicalPriceRequest",
             :namespace => namespace,


### PR DESCRIPTION
A type definition can have an element specified like this:

```
<element ref="tns:someElement" maxOccurs="unbounded"/>
```

where 'someElement' is the name of an element definied in the schema.