### PR TITLE
support pretty print, fixes #17

### DIFF
--- a/lib/lolsoap/builder.rb
+++ b/lib/lolsoap/builder.rb
@@ -15,17 +15,17 @@ module LolSoap
   #   builder['ns2'].someTag
   #   # => <ns2:someTag/>
   class Builder
-    RESERVED_METHODS = %w(object_id respond_to_missing? inspect === to_s)
+    RESERVED_METHODS = %w(object_id respond_to_missing? inspect === to_s instance_variables instance_eval)
 
     alias :__class__ :class
     instance_methods.each do |m|
-      undef_method m unless RESERVED_METHODS.include?(m.to_s) || m =~ /^__/
+      undef_method m unless RESERVED_METHODS.include?(m.to_s) || m =~ /^__/ || m =~ /^pretty_print/
     end
 
     # @private
     class Prefix
       instance_methods.each do |m|
-        undef_method m unless RESERVED_METHODS.include?(m.to_s) || m =~ /^__/
+        undef_method m unless RESERVED_METHODS.include?(m.to_s) || m =~ /^__/ || m =~ /^pretty_print/
       end
 
       def initialize(owner, prefix)

--- a/test/unit/test_builder.rb
+++ b/test/unit/test_builder.rb
@@ -1,6 +1,8 @@
 require 'helper'
 require 'lolsoap/builder'
 
+require 'pp'
+
 module LolSoap
   describe Builder do
     let(:doc) { MiniTest::Mock.new }
@@ -87,6 +89,15 @@ module LolSoap
       expect_node_added node.namespace_scopes[0], 'foo' do
         subject['b'].foo
       end
+    end
+
+    # see https://github.com/loco2/lolsoap/issues/18
+    # would raise if pretty print causes doc.create_element to be called:
+    #   NoMethodError: unmocked method :create_element
+    it 'can be pretty printed' do
+      out = ''
+      PP.pp(subject, out)
+      out.include?("LolSoap::Builder").must_equal true
     end
 
     describe '#__node__' do


### PR DESCRIPTION
For pretty printing to work we need to preserve some more methods.
Otherwise `PP#pp` calls them and they end-up added to request.
This is especially helpful when making calls from `pry` shell. Without
the fix just generating a request within a pry shell results in extra
elements being added.