### PR TITLE
NullType#element does not return instance of NullElement

### DIFF
--- a/lib/lolsoap/wsdl/null_type.rb
+++ b/lib/lolsoap/wsdl/null_type.rb
@@ -9,7 +9,7 @@ class LolSoap::WSDL
     end
 
     def element(name)
-      NullType.new
+      NullElement.new
     end
 
     def ==(other)


### PR DESCRIPTION
`NullType#element` is currently returning an instance of `NullType`. I believe this is a typo. The behavior should be for `NullType#element` to return an instance of `NullElement`.