### PR TITLE
Support unqualified form for elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ pkg
 
 Gemfile.lock
 
+Dockerfile
+
 # Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
 #
 # * Create a file at ~/.gitignore

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Development sponsored by [Loco2](http://loco2.com/).
 
 ## Changelog ##
 
+### 0.9 ###
+
+* Support unqualified form for elements in a schema
+
 ### 0.8 ###
 
 * Use namespaces when looking up definitions

--- a/lib/lolsoap/wsdl.rb
+++ b/lib/lolsoap/wsdl.rb
@@ -135,7 +135,7 @@ module LolSoap
       Element.new(
         self,
         params[:name],
-        prefix(params[:namespace]),
+        params[:namespace] && prefix(params[:namespace]),
         type_reference(params[:type]),
         params[:singular]
       )

--- a/test/fixtures/stock_quote.wsdl
+++ b/test/fixtures/stock_quote.wsdl
@@ -12,7 +12,8 @@
   <types>
     <schema targetNamespace="http://example.com/stockquote.xsd"
             xmlns:xsd3="http://example.com/stockquote.xsd"
-            xmlns="http://www.w3.org/2001/XMLSchema">
+            xmlns="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified">
       <attributeGroup name="BaseRequestAttributes">
         <attribute name="signature" type="xs:string"/>
       </attributeGroup>

--- a/test/integration/test_envelope.rb
+++ b/test/integration/test_envelope.rb
@@ -28,7 +28,7 @@ module LolSoap
       el.wont_equal nil
       el.text.to_s.must_equal 'LOCO2'
 
-      el = doc.at_xpath('//ns0:tradePriceRequest/ns0:specialTickerSymbol/ns1:name', doc.namespaces)
+      el = doc.at_xpath('//ns0:tradePriceRequest/ns0:specialTickerSymbol/name', doc.namespaces)
       el.wont_equal nil
       el.text.to_s.must_equal 'LOCOLOCOLOCO'
 

--- a/test/unit/test_builder.rb
+++ b/test/unit/test_builder.rb
@@ -35,6 +35,7 @@ module LolSoap
 
       doc.expect(:create_element, sub_node, args)
       sub_node.expect(:namespace=, nil, [namespace])
+      sub_node.expect(:namespace, namespace)
       node.children.expect(:<<, nil, [sub_node])
 
       yield sub_node

--- a/test/unit/test_wsdl_parser.rb
+++ b/test/unit/test_wsdl_parser.rb
@@ -96,7 +96,7 @@ module LolSoap
             :elements  => {
               'name' => {
                 :name      => 'name',
-                :namespace => namespace2,
+                :namespace => nil,
                 :type      => [xs, "string"],
                 :singular  => true
               }


### PR DESCRIPTION
"unqualified" form means that elements from the target namespace of a schema are not required to be qualified with the namespace prefix. "unqualified" is the default form. It can be changed by setting a `form="qualified"` attribute on the element or a `elementFormDefault="qualified"` attribute on the schema, in which case it'll apply to all elements in the schema.
    
Before this change lolsoap always used qualified form regardless of the attributes in the schema and so all elements in requests were always prefixed with the namespace. 
   
After this change only elements for which qualified form is specified will be prefixed.