### PR TITLE
Load also abstract types 

### DIFF
--- a/lib/lolsoap/wsdl_parser.rb
+++ b/lib/lolsoap/wsdl_parser.rb
@@ -307,12 +307,18 @@ module LolSoap
         types = {}
         each_node('xs:complexType[not(@abstract="true")]') do |node, schema|
           type = Type.new(self, schema, node)
-          types[type.id] = {
-            :name       => type.name,
-            :namespace  => type.namespace,
-            :elements   => type.elements,
-            :attributes => type.attributes
-          }
+          types[type.id] = type_record(type)
+        end
+        types
+      end
+    end
+
+    def abstract_types
+      @abstract_types ||= begin
+        types = {}
+        each_node('xs:complexType[@abstract="true"]') do |node, schema|
+          type = Type.new(self, schema, node)
+          types[type.id] = type_record(type)
         end
         types
       end
@@ -445,6 +451,16 @@ module LolSoap
         schema = Schema.from_node(node.at_xpath('parent::xs:schema', ns))
         node_class.new(self, schema, node)
       end
+    end
+
+    private
+    def type_record(type)
+      {
+        :name       => type.name,
+        :namespace  => type.namespace,
+        :elements   => type.elements,
+        :attributes => type.attributes
+      }
     end
   end
 end

--- a/lolsoap.gemspec
+++ b/lolsoap.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'nokogiri', '~> 1.5'
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "minitest", "~> 2.10.0"
   spec.add_development_dependency "yard"
 end

--- a/test/integration/test_wsdl.rb
+++ b/test/integration/test_wsdl.rb
@@ -28,6 +28,11 @@ module LolSoap
         o.input.body.content.name.must_equal 'historicalPriceRequest'
       end
 
+      subject.abstract_types.length.must_equal 1
+      subject.abstract_types.fetch('BaseRequest').tap do |t|
+        t.prefix.must_equal 'ns0'
+      end
+
       subject.types.length.must_equal 4
       subject.types.fetch('TradePriceRequest').tap do |t|
         t.prefix.must_equal 'ns0'

--- a/test/unit/test_wsdl.rb
+++ b/test/unit/test_wsdl.rb
@@ -59,8 +59,16 @@ module LolSoap
               :attributes => ['id'],
               :namespace  => namespace
             }
-         },
-         :elements => {
+          },
+          :abstract_types => {
+            [namespace, 'BaseBrush'] => {
+              :name => 'BaseBrush',
+              :elements => {},
+              :attributes => ['id'],
+              :namespace  => namespace
+            },
+          },
+          :elements => {
             [namespace, 'brush'] => {
               :name      => 'brush',
               :namespace => namespace,
@@ -172,6 +180,16 @@ module LolSoap
         end
       end
 
+      describe '#abstract_types' do
+        it 'returns a hash of abstract types' do
+          subject.abstract_types.length.must_equal 1
+
+          subject.abstract_types['BaseBrush'].tap do |t|
+            t.attributes.must_equal ['id']
+          end
+        end
+      end
+
       describe '#type' do
         it 'returns a single type' do
           subject.type(namespace, 'Brush').must_equal subject.types.fetch('Brush')
@@ -179,6 +197,28 @@ module LolSoap
 
         it 'returns a null object if a type is missing' do
           subject.type(namespace, 'FooBar').must_equal WSDL::NullType.new
+        end
+
+        it 'returns a null object for abstract types' do
+          subject.type(namespace, 'BaseBrush').must_equal WSDL::NullType.new
+        end
+
+        describe 'when abstract types are allowed' do
+          subject { WSDL.new(parser, :allow_abstract_types => true) }
+
+          it 'returns an abstract type' do
+            subject.type(namespace, 'BaseBrush').must_equal subject.abstract_types.fetch('BaseBrush')
+          end
+        end
+      end
+
+      describe '#abstract_type' do
+        it 'returns a single type' do
+          subject.abstract_type(namespace, 'BaseBrush').must_equal subject.abstract_types.fetch('BaseBrush')
+        end
+
+        it 'returns a null object if a type is missing' do
+          subject.abstract_type(namespace, 'FooBar').must_equal WSDL::NullType.new
         end
       end
     end

--- a/test/unit/test_wsdl_parser.rb
+++ b/test/unit/test_wsdl_parser.rb
@@ -107,6 +107,26 @@ module LolSoap
       end
     end
 
+    describe "#abstract_types" do
+      it 'returns the abstract types, with attributes and namespace' do
+        subject.abstract_types.must_equal({
+          [namespace, "BaseRequest"] => {
+            :name => "BaseRequest",
+            :namespace => "http://example.com/stockquote.xsd",
+            :elements => {
+              "accountId" => {
+                :name => "accountId",
+                :namespace => "http://example.com/stockquote.xsd",
+                :type => [xs, "string"],
+                :singular=>true
+              }
+            },
+            :attributes=>["signature"]
+          },
+        })
+      end
+    end
+
     describe '#elements' do
       it 'returns the elements with inline types' do
         subject.elements.must_equal({


### PR DESCRIPTION
It's probably rare but some WSDL files use abstract types in operation definitions. Without this change it's impossible to build messages for such operations.

I'm also bumping bundler and rake dependencies here.