### PR TITLE
Use frozen_string_literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Development sponsored by [Loco2](http://loco2.com/).
 
 ## Changelog ##
 
+### 0.11 ###
+
+* Use `frozen_string_literal` to improve speed/memory usage
+
 ### 0.10 ###
 
 * Added support for using WSDL with abstract types in operation definitions

--- a/lib/lolsoap/builder.rb
+++ b/lib/lolsoap/builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'lolsoap/wsdl'
 
 module LolSoap

--- a/lib/lolsoap/version.rb
+++ b/lib/lolsoap/version.rb
@@ -1,3 +1,3 @@
 module LolSoap
-  VERSION = "0.10.0"
+  VERSION = "0.11.0"
 end

--- a/lib/lolsoap/wsdl.rb
+++ b/lib/lolsoap/wsdl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'lolsoap/wsdl_parser'
 
 module LolSoap

--- a/lib/lolsoap/wsdl_parser.rb
+++ b/lib/lolsoap/wsdl_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'nokogiri'
 require 'cgi'
 


### PR DESCRIPTION
When processing large WSDL's, this can provide non-trival boosts in
speed/memory usage for no cost.

In a real-life scenario where the WSDL is defined by a 15,000 line XML
document, the `memory_monitor` gem showed that the process as a whole
allocated the following amounts of memory:

Before: 54,613,018 bytes
After:  51,802,458 bytes

This is a 2.8MB, or 5% saving.

As a point of interest, the largest saving came from ':' in the
`namespace_and_name` method.